### PR TITLE
RIG - check forbidden values and pass length

### DIFF
--- a/lib/rex/random_identifier/generator.rb
+++ b/lib/rex/random_identifier/generator.rb
@@ -171,10 +171,20 @@ class Rex::RandomIdentifier::Generator
       end
       # Try to make another one if it collides with a previously
       # generated one.
-      break unless @name_by_value.key?(ident) or @opts[:forbidden].include?(ident)
+      break unless @name_by_value.key?(ident) or forbid_id?(ident)
     end
 
     ident
+  end
+
+  #
+  # Check if an identifier is forbidden
+  #
+  # @param str [String] String for which to check permissions
+  #
+  # @return [Boolean] Is identifier forbidden?
+  def forbid_id?(ident = nil)
+    ident.nil? or @opts[:forbidden].any? {|f| f.match(/^#{ident}$/i) }
   end
 
 end

--- a/lib/rex/random_identifier/generator.rb
+++ b/lib/rex/random_identifier/generator.rb
@@ -33,13 +33,15 @@ class Rex::RandomIdentifier::Generator
     :min_length => 3,
     # This should be pretty universal for identifier rules
     :char_set => Rex::Text::AlphaNumeric+"_",
-    :first_char_set => Rex::Text::LowerAlpha
+    :first_char_set => Rex::Text::LowerAlpha,
+    :forbidden => []
   }
 
   # @param opts [Hash] Options, see {DefaultOpts} for default values
   # @option opts :max_length [Fixnum]
   # @option opts :min_length [Fixnum]
   # @option opts :char_set [String]
+  # @option opts :forbidden [Array]
   def initialize(opts={})
     # Holds all identifiers.
     @value_by_name = {}
@@ -82,10 +84,10 @@ class Rex::RandomIdentifier::Generator
   #   identifier. This is what you would normally call the variable if
   #   you weren't generating it.
   # @return [String]
-  def get(name)
+  def get(name, len = nil)
     return @value_by_name[name] if @value_by_name[name]
 
-    @value_by_name[name] = generate
+    @value_by_name[name] = generate(len)
     @name_by_value[@value_by_name[name]] = name
 
     @value_by_name[name]
@@ -150,7 +152,7 @@ class Rex::RandomIdentifier::Generator
   # @return [String] A string that matches <tt>[a-z][a-zA-Z0-9_]*</tt>
   # @yield [String] The identifier before uniqueness checks. This allows
   #   you to modify the value and still avoid collisions.
-  def generate(len=nil)
+  def generate(len = nil)
     raise ArgumentError, "len must be positive integer" if len && len < 1
     raise ExhaustedSpaceError if @value_by_name.length >= @max_permutations
 
@@ -169,7 +171,7 @@ class Rex::RandomIdentifier::Generator
       end
       # Try to make another one if it collides with a previously
       # generated one.
-      break unless @name_by_value.key?(ident)
+      break unless @name_by_value.key?(ident) or @opts[:forbidden].include?(ident)
     end
 
     ident

--- a/spec/rex/random_identifier/generator_spec.rb
+++ b/spec/rex/random_identifier/generator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timeout'
 
 
 RSpec.describe Rex::RandomIdentifier::Generator do
@@ -13,6 +14,7 @@ RSpec.describe Rex::RandomIdentifier::Generator do
   it { is_expected.to respond_to(:get) }
   it { is_expected.to respond_to(:store) }
   it { is_expected.to respond_to(:to_h) }
+  it { is_expected.to respond_to(:forbid_id?) }
 
   describe "#generate" do
     it "should respect :min_length" do


### PR DESCRIPTION
Allow the Generator to receive an array of forbidden vars on init
which are checked along with the hash of existing vars prior to
saving it in the hash. This should prevent the unlikely case of,
for argument's sake, a PSH RIG producing "true" which would be
"$true" after template interpolation.

Permit :get (aka :init_var) to take a second length argument which
is already accepted by the underlying :generate method.