### PR TITLE
Update setup-ruby action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,23 +32,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
-      - name: Setup bundler
-        run: |
-          gem install bundler
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: ${{ matrix.test_cmd }}
         run: |
           echo "${CMD}"


### PR DESCRIPTION
This PR uses the updated ruby setup tool [ruby/setup-ruby@v1](https://github.com/ruby/setup-ruby) instead of the older [actions/setup-ruby@v1](https://github.com/actions/setup-ruby).