### PR TITLE
Add PHP option to language support in generator

### DIFF
--- a/lib/rex/random_identifier/generator.rb
+++ b/lib/rex/random_identifier/generator.rb
@@ -269,7 +269,8 @@ class Rex::RandomIdentifier::Generator
     jsp: JSPOpts,
     javascript: JavaScriptOpts,
     python: PythonOpts,
-    powershell: PowershellOpts
+    powershell: PowershellOpts,
+    php: PHPOpts
   }
 
   # @param opts [Hash] Options, see {DefaultOpts} for default values


### PR DESCRIPTION
This pull request fixes the [Issue](https://github.com/rapid7/metasploit-framework/issues/20539)